### PR TITLE
docs: directory-indexing 추가

### DIFF
--- a/Nginx/directory-indexing.md
+++ b/Nginx/directory-indexing.md
@@ -1,0 +1,20 @@
+## Directory Indexing with Nginx
+
+> 파일 리스트 서버를 만들기 위한 용도로 사용된다.
+> static 리소스를 담고 서빙하는 용도나 빌드 후 릴리즈 파일들을 넣는 용도로 사용할 수 있다.
+
+```bash
+server {
+	server_name test.domain.com;
+
+	location = / {
+        # root 경로에 있는 파일을 화면에 띄워준다.
+        # root vs alias
+        # - root: location에 매칭된 부분을 root 경로에 추가하여 조회한다.
+        # - alias: location에 매칭된 부분은 없애고 항상 alias에서 설정한 경로의 파일들을 autoindex 한다.
+        root /var/datas;
+        # autoindex 옵션으로 indexing 설정을 해준다.(default: off)
+        autoindex on;
+	}
+}
+```


### PR DESCRIPTION
## Today I Learned

- 웹 보안 준수 사항을 살펴보다가 **디렉토리 인덱싱 버그**에 대해서 알게 되었다. 
- 디렉토리 인덱싱 설정을 해두었을 때, 공개하는 것을 의도하지 않은 파일에 접근하여 다운로드할 수 있다는 버그였다.
- 다행히도 nginx에서는 디렉토리 인덱싱의 기본값을 false로 설정되어 있어서 이를 모르고 사용하더라도 디렉토리 인덱싱 버그에서 자유로울 수 있었다. 
  - 설정 방법: `autoindex    on`
- 모호했던 개념인 root와 alias의 차이점도 같이 학습할 수 있었다.
- 디렉토리 인덱싱을 보안 내용으로 처음 접해서 악성 유저의 사용 방식을 먼저 알게 되어서 사용에 소극적이었지만, 아주아주 유용한 기능이고, 나중에 프로젝트에 꼭 한번 적용해보고싶다!

## Further study

- [ ] 디렉토리 인덱싱 사용법은 익혔는데, 디렉토리 인덱싱 버그를 해결하기 위한 방법은 아직 모호하다. 좀 더 알아봐야겠다.
