### PR TITLE
Docs/nginx with docker

### DIFF
--- a/Nginx/nginx-with-docker.md
+++ b/Nginx/nginx-with-docker.md
@@ -1,4 +1,4 @@
-## Nginx with Docker
+## Nginx - Reverse Proxy (w/ Docker)
 
 > Nginx를 이용해서 Reverse Proxy를 구현할 수 있다. 외부에서 내부 서버로 접근하는 경우, 웹서버를 먼저 거쳐서 내부 서버로 프록시해준다.
 > Reverse Proxy를 사용하여 얻을 수 있는 장점은 크게 "보안"과 "로드밸런싱" 두가지로 볼 수 있다.


### PR DESCRIPTION
## Today I Learned

- 프론트엔드 서비스와 백엔드 서비스를 직접 외부에 공개해서 사용하는 것은 보안상 문제가 되기 때문에 Nginx를 알아보게 되었다.
- Nginx는 Reverse Proxy 기능을 지원하여, Nginx에서 열어둔 특정 포트만을 이용해 서비스를 제공할 수 있다.
- 즉, Nginx는 외부 요청과 내부 서비스(WAS) 간의 중계기 역할을 한다.
- 어느 WAS에 대한 요청인지 분기할 수 있는 키워드가 필요하여, 백엔드 WAS 요청인 경우 `/api` 키워드를 추가하게 되었다.
  - WAS: 프론트엔드, 백엔드
- Nginx에서는 루트에 `api` 키워드가 추가된 요청은 백엔드 WAS로 요청을 전달하고, `api`를 제외하도록 설정해두었다.
- 배포 시, nginx 설정을 간소화하기 위해 Docker 설정을 해주었다.
- docker-compose 내 컨테이너 간 네트워킹할 수 있도록 `network`를 설정하여 `depends_on:` 옵션을 통해 컨테이너들을 연결했다.
- 도커 설정으로 nginx와 각 WAS에서 하드 코딩으로 ip를 설정하지 않을 수 있었다.
  - 컨테이너 이름으로 연결할 수 있다.

## Further study

- [x] 보안 상 포트를 외부로 포트를 공개하는 `ports` 옵션 대신 컨테이너 간 통신만 지원할 수 있는 `expose` 옵션을 이용하는 것으로 수정해봐야겠다.