### PR TITLE
nginx: Note 추가, expose vs ports

### DIFF
--- a/Nginx/nginx-with-docker.md
+++ b/Nginx/nginx-with-docker.md
@@ -79,8 +79,10 @@ services:
     image: app-frontend:v1.0
     container_name: frontend
     restart: always
-    ports:
-      - 3000:3000
+    # ports:
+    #   - 3000:3000
+    expose:
+      - 3000
     networks:
       - app_network
 
@@ -88,8 +90,10 @@ services:
     image: app-backend:v1.0
     container_name: backend
     restart: always
-    ports:
-      - 8080:8080
+    # ports:
+    #   - 8080:8080
+    expose:
+      - 8080
     networks:
       - app_network
 
@@ -116,5 +120,11 @@ networks:
 ```
 
 ---
+
+## Notes
+
+- expose vs ports (docker-compose.yml)
+  - expose: 호스트 내 다른 컨테이너 사이에서만 포트가 노출되어 액세스 가능하다.
+  - ports: 호스트 외부의 다른 호스트들도 호스트 포트번호로 액세스 가능하다.
 
 Retrospective: [PR #2](https://github.com/siwoo-h/TIL/pull/2)


### PR DESCRIPTION
## Today I Learned

- WAS의 포트를 외부로 노출하면 보안 상 이슈가 되기 때문에, nginx 포트만 공개해두고 WAS 포트는 외부에 노출하지 않도록 설정했다.
- 포트를 설정하는 방법이 두가지가 있는데, 이 두 옵션의 차이점이 외부 노출 여부이다.
  - ports: 호스트 외부의 다른 호스트들도 호스트 포트번호로 액세스 가능하다.
  - expose: 호스트 내 다른 컨테이너 사이에서만 포트가 노출되어 액세스 가능하다.
- 컨테이너들은 networks에 동일한 네트워크를 설정해두었기 때문에 동일한 망으로 설정되어 컨테이너 간 통신이 가능하다.

## Further study

- [ ] TIL 파일에는 적지 않았지만, 데이터베이스는 포트를 expose로 설정할 수 없었다. 짐작컨데, 1) volume을 마운트하고 있어서 2) 외부포트와 내부포트를 다르게 설정하고 있어서(로컬 DB 포트와 충돌을 방지하기 위해서 외부/내부 포트를 다르게 했다) 예상되는 원인이 이 두가지이다. 이 내용을 구체적으로 정리해야겠다.
