### PR TITLE
Node/crypto

### DIFF
--- a/Node/crypto.md
+++ b/Node/crypto.md
@@ -15,3 +15,30 @@ pbkdf2("secret", "salt", 100000, 64, "sha512", (err, derivedKey) => {
   console.log(derivedKey.toString("hex")); // '3745e48...08d59ae'
 });
 ```
+
+특정 개인정보를 암호화하여 저장하고, 복호화하여 화면에 노출해야하는 경우에는 양방향 암호화를 이용해야한다.
+
+```js
+const { scrypt, randomFill, createCipheriv } = await import("node:crypto");
+
+const algorithm = "aes-192-cbc";
+const password = "Password used to generate key";
+
+// First, we'll generate the key. The key length is dependent on the algorithm.
+// In this case for aes192, it is 24 bytes (192 bits).
+scrypt(password, "salt", 24, (err, key) => {
+  if (err) throw err;
+  // Then, we'll generate a random initialization vector
+  randomFill(new Uint8Array(16), (err, iv) => {
+    if (err) throw err;
+
+    const cipher = createCipheriv(algorithm, key, iv);
+
+    let encrypted = cipher.update("some clear text data", "utf8", "hex");
+    encrypted += cipher.final("hex");
+    console.log(encrypted);
+  });
+});
+```
+
+key, password 에 길이 제한이 있으니 주의하자!


### PR DESCRIPTION
## Today I Learned

- DB에 암호화하여 저장하는 칼럼이 존재하는 경우는 비밀번호와 그 이외 개인정보인 데이터가 있었다.
- 비밀번호는 단방향 암호화 처리로 사용자가 입력한 비밀번호를 DB에 저장한 알고리즘과 동일한 방식으로 변환하여 비교하는 방식으로 해결할 수 있었다.
- 개인정보 데이터의 경우 암호화하여 저장하지만, 인증된 사용자 화면에서는 복호화하여 노출해야하기 때문에 양방향 암호화처리가 필요했다.
- 적용하다가 디코딩 시, 문자열이 깨져서 출력되어 막혔다.
- 이 문제의 원인은 암호화에 사용되는 key, iv 파라미터의 길이 제한이었다.
  > Key length is dependent on the algorithm. In this case for aes192, it is 24 bytes (192 bits).
  > The length of the initialization vector (nonce) N must be between 7 and 13 bytes (7 ≤ N ≤ 13).

## Further study

- [ ] 예제에 적용할 때는 iv를 고정값으로 처리했다. 공식문서에서는 랜덤한 값을 권고하고 있는데, 이것을 반영해봐야겠다.
  > Initialization vectors should be unpredictable and unique; ideally, they will be cryptographically random.