### PR TITLE
Nest/rate limiting/throttler

### DIFF
--- a/NestJS/rate-limiting.md
+++ b/NestJS/rate-limiting.md
@@ -137,5 +137,15 @@ app.use(
   - 엔드포인트에 관계없이 동일 IP의 요청을 제한할 수 있어서, 서버 부하를 줄일 수 있다.
 - 단일 엔드포인트의 메모리 누수를 막기 위해서는 지역적으로 `@nestjs/throttler`를 채택했다.
   - NestJS 공식문서에서 제안하는 방법이고, 사용하기 편하다.
-- guard의 canActivate 핸들러 결과가 false 인 경우, 403 에러 코드를 응답한다.
+- Guard의 canActivate 핸들러 결과가 false 인 경우, 403 에러 코드로 응답한다.
   - 다른 에러 코드를 반환하고 싶다면, `throw new UnauthorizedException();` 와 같이 예외 처리하면 된다.
+
+### Guard 검사에서 통과되지 않는 경우, 트래픽 제한(rate-limit)이 의도대로 동작하지 않는다?
+
+- rate-limit는 트래픽 부하를 줄이기 위해 서버에서는 요청을 처리하지 않고, 바로 429 에러를 리턴하는 것이다.
+- 따라서, 서버에 부하를 주지 않는 경우에는 트래픽 제한이 필요없다.
+- `@nestjs/throttler`의 흐름은 다음과 같다.
+  1. API 요청
+  2. Guard 검사
+  3. return true? rate-limit 횟수 카운트한다. -> 요청은 계속 들어가고, 429 에러를 반환한다.
+  4. return false? rate-limit 횟수 카운트하지 않은 채, Guard에서 예외 처리한다. -> 요청은 계속 들어가고, Guard에서 예외처리한다.(default: 403 Forbidden)


### PR DESCRIPTION
## Today I Learned

- rate-limit 설정을 위해 기존 인증 방식을 미들웨어에서 처리하던 것을 가드 처리로 변경하였다.
  - rate-limit 설정이 엔드포인트에 의존하여 처리되는데, 엔드포인트로 요청이 들어가기전 미들웨어에서 reject되어서 트래픽제한이 의도대로 동작하지 않았다고 생각했기 때문이다.
- 적용하고 나니, rate-limit가 의도대로 동작하지 않았다..
  - 적용되는 구간은 가드를 정상적으로 통과한 경우였다.
- 이로써 rate-limit 처리방식을 이해할 수 있었다.
  - 내가 사용한 `@nestjs/throttler` 패키지에 한해서 정리한 내용이다.
  - 트래픽 제한을 전역적으로 설정할 수는 있지만, 엔드포인트 단위로 요청을 카운팅한다.
  - 따라서 요청 자체를 막는 것이 아니라 요청을 서버에서 처리하기 전에 가드에서 예외처리하는 것이었다.
- 그렇다면, 가드 검증이 유효하지 않은 경우는 어떤 처리가 우선일까? rate-limit 설정일까? 가드 검증 예외처리일까?
  - 가드 검증 예외처리더라
  - 그래서 잘못된 요청을 보냈을 때(가드에서 걸리는 요청인 경우)는 아무리 요청을 보내더라도 트래픽 제한 예외처리는 발생하지 않더라.
- 그럼 무제한으로 요청을 보내면, 무분별 요청 공격은 어떻게 막지?
  - 이 상황을 방지하기 위해서는 엔드포인트 검증을 하지 않고 동일 IP의 요청 횟수 자체를 거르는 `express-rate-limit` 패키지를 이용한다.

## Further study

- [ ] 다른 패키지에서는 어떻게 동작하는지도 확인해봐야겠다.
