### PR TITLE
Nestjs/http exception

### DIFF
--- a/NestJS/http-exception.md
+++ b/NestJS/http-exception.md
@@ -1,0 +1,58 @@
+# HTTP Exception
+
+비즈니스 로직 내 예외 처리를 해줘야 하는 다양한 경우가 있는데, 예기치 못한 예외가 발생하는 경우에는 어떻게 처리할까?<br>
+Nest.js에서는 Exception Filter를 내장하고 있다.<br>
+표준 HttpException 예외로 처리되지 않은 예외가 발생하는 경우, `InternalServerException`으로 처리하도록 설정할 수 있다.
+
+```js
+// http-exception.filter.ts
+// 공식 문서 참고: https://docs.nestjs.com/exception-filters#custom-exceptions
+// HttpException 인스턴스인 경우에는 응답으로 리턴하고,
+// 그렇지 않은 경우에는 InternalServerException으로 응답을 내보낸다.
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus } from "@nestjs/common";
+import { Request, Response } from "express";
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    if (exception instanceof HttpException) {
+        response
+          .status(exception.getStatus())
+          .json(exception.getResponse());
+    } else {
+        response
+          .status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .json({
+            statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+            timestamp: new Date().toISOString(),
+            request: `${request.method} ${request.url}`,
+          });
+    }
+  }
+}
+
+```
+
+구현한 `HttpExceptionFilter`를 모든 경로에 설정한다.
+
+```js
+import { Module } from "@nestjs/common";
+import { APP_FILTER } from "@nestjs/core";
+import { HttpExceptionFilter } from "@src/filter/http-exception.filter.ts";
+
+@Module({
+  providers: [
+    {
+      provide: APP_FILTER,
+      useClass: HttpExceptionFilter,
+    },
+  ],
+})
+export class AppModule {}
+```
+
+Exception Filter를 이용하여 일관적인 예외로 응답 처리할 수 있다.

--- a/NestJS/http-exception.md
+++ b/NestJS/http-exception.md
@@ -55,4 +55,6 @@ import { HttpExceptionFilter } from "@src/filter/http-exception.filter.ts";
 export class AppModule {}
 ```
 
-Exception Filter를 이용하여 일관적인 예외로 응답 처리할 수 있다.
+Exception Filter를 이용하여 일관적인 예외로 응답 처리할 수 있다.<br>
+설령, 예기치 못한 에러가 발생할지라도 너무 걱정 말자.<br>
+Exception Filter에서 잡아줄 것이다.<br>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## 📖 NestJS
 
 - [File Upload](/NestJS/file-upload.md)
+- [HTTP Exception](/NestJS/http-exception.md)
 - [Rate Limiting](/NestJS/rate-limiting.md)
 - [Task Scheduling](/NestJS/task-scheduling.md)
 


### PR DESCRIPTION
## Today I Learned

- 직접 정의한 예외가 아닌 에러가 발생한 경우 `throw new InternalServerException(error)`로 처리하고 있었다.
- 여기서 예기치 못한 문제가 발생하게 되었다.
- A 서비스에서 B 서비스를 가져와서 사용해야하는 경우, A 서비스에서 사용자 정의 에러가 아닌, B 서비스의 예외를 A 서비스에서 분기해줘야하는 번거로움이 있었다.
- 추후 리팩터를 하다가 "사용하지 않는 예외 분기네? 제거해야겠다!" 고 생각해서 제거했다가, InternalServerException으로 처리되는 일이 발생했다.
- 이렇게 일일이 해줘야하는 방법 뿐일까?
- 역시 아니었다. Nest.js에 내장된 Exception Filter가 있었다.
- 예외 처리를 리팩터하면서, 전반적인 예외 타입도 정의하는 중이다.
- 더 좋은 예외 처리 방법을 알아보고 있다.
 
## Further study

- [ ] 예외 처리를 하는 다양한 방법이 있더라. 타 기업에서는 HTTP 표준 코드 외에 사내 코드를 설정하여 FE, BE 커뮤니케이션에 이용하더라! 어떻게 하는 방법이 가장 효율적일지 알아보고있다.
