### PR TITLE
Typeorm/pagination/order-by

### DIFF
--- a/TypeORM/pagination.md
+++ b/TypeORM/pagination.md
@@ -11,3 +11,13 @@ take, skip를 적용해봤을 때 원하는 결과를 볼 수 없었다.
 그 이유는 사용 방식의 차이에 있었다.
 typeorm querybuilder에서 getRawMany()로 raw data를 반환하도록 구현해뒀는데, 이 때는 `skip`과 `take`가 제대로 작동하지 않는다.
 raw data를 반환할 때는 `limit`, `offset`을 사용해야 한다.
+
+# OrderBy
+
+orderBy로 정렬한 이후에 limit, offset으로 페이지네이션을 처리할 때, 예상과 다른 결과가 조회되는 경우가 있다.
+원인은 중복된 값으로 정렬이 되는 경우, limit, offset은 기준 없이 페이지네이션이 되는 것이었다.
+해결 방법은 대비할 수 있는 정렬을 추가해두는 것이다.
+
+```js
+createQueryBuilder("user").orderBy("user.name").addOrderBy("user.id");
+```

--- a/TypeORM/pagination.md
+++ b/TypeORM/pagination.md
@@ -12,7 +12,7 @@ take, skip를 적용해봤을 때 원하는 결과를 볼 수 없었다.
 typeorm querybuilder에서 getRawMany()로 raw data를 반환하도록 구현해뒀는데, 이 때는 `skip`과 `take`가 제대로 작동하지 않는다.
 raw data를 반환할 때는 `limit`, `offset`을 사용해야 한다.
 
-# OrderBy
+# AddOrderBy
 
 orderBy로 정렬한 이후에 limit, offset으로 페이지네이션을 처리할 때, 예상과 다른 결과가 조회되는 경우가 있다.
 원인은 중복된 값으로 정렬이 되는 경우, limit, offset은 기준 없이 페이지네이션이 되는 것이었다.


### PR DESCRIPTION
## Today I Learned

- orderBy로 정렬한 이후에 limit, offset으로 페이지네이션을 처리할 때, 예상과 다른 결과가 조회되는 경우가 있다.
  - 서로 다른 페이지 결과에서 데이터가 중복되는 경우가 있었다.
- 원인은 중복된 값으로 정렬이 되는 경우, limit, offset은 기준 없이 페이지네이션이 되는 것이었다.
- 해결 방법은 `addOrderBy`를 이용하여 정렬을 추가해두는 것이다.
  - 주로 유일한 값을 가지는 DB id를 기준으로 하더라

## Further study

- [ ] ORM을 이용해 실제 쿼리가 어떻게 동작하는지 확인하여 최적화하는 연습을 해봐야겠다.
