### PR TITLE
Docker/links

### DIFF
--- a/Docker/links.md
+++ b/Docker/links.md
@@ -1,0 +1,41 @@
+# links
+
+도커 네트워크 구조 중 `links` 옵션이 있다.
+`links`는 같은 네트워크 내 컨테이너 서비스 간 통신을 할 때 사용한다.
+
+## 사용하기
+
+```yml
+version: "3.8"
+
+services:
+  service-a:
+    image: a-image:latest
+    expose:
+      - 3000
+    volumes:
+      - ./a:/app
+    environment:
+      SERVICE_B_URL: service-b
+    links:
+      - service-b
+    networks:
+      - app_network
+
+  service-b:
+    image: b-image:latest
+    expose:
+      - 5000
+    volumes:
+      - ./b:/app
+    environment:
+      SERVICE_A_URL: service-a
+    links:
+      - service-a
+    networks:
+      - app_network
+
+networks:
+  app_network:
+    driver: bridge
+```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 - [ENV file](/Docker/env-file.md)
 - [ENV vs ARG](/Docker/env-vs-arg.md)
+- [Links](/Docker/links.md)
 
 ## 📖 Github
 


### PR DESCRIPTION
## Today I Learned

- 도커 컨테이너 서비스 내 네트워크에서 ip를 공유할 수 있는 방법에 대해 찾던 중에 `links` 옵션에 대해 알게되었다.
- 서비스는 매번 고정된 ip를 가지는 것이 아니기 때문에 연결시켜주는 방법이 필요했다.
- 이전에 service name을 depends_on에 추가한 후 ip 대신 전댈해주는 방법을 사용했었는데, 어떤 경우에서는 `dedends_on`으로는 안되더라.
- 게다가 `links`는 deprecated로 표시되어있던데, `links`를 대체할 수 있는 방법과 `depends_on`과의 차이를 알아봐야겠다.

## Further study

- [ ] 공식문서에서 `links` 옵션 대신 권고하고 있는 방법
- [ ] `links` vs `depends_on`
